### PR TITLE
Pit team record recycler

### DIFF
--- a/ScoutingRadar2022/.idea/deploymentTargetDropDown.xml
+++ b/ScoutingRadar2022/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\katri\.android\avd\Nexus_7_API_30.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="adb-eqobuweyeedikvdu-VqpH8E._adb-tls-connect._tcp" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-03-15T19:14:58.486457Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-04-16T21:26:37.731448300Z" />
   </component>
 </project>

--- a/ScoutingRadar2022/.idea/deploymentTargetDropDown.xml
+++ b/ScoutingRadar2022/.idea/deploymentTargetDropDown.xml
@@ -6,12 +6,12 @@
         <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="SERIAL_NUMBER" />
-            <value value="adb-eqobuweyeedikvdu-VqpH8E._adb-tls-connect._tcp" />
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\Ishaan\.android\avd\Nexus_7_API_30.avd" />
           </Key>
         </deviceKey>
       </Target>
     </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-04-16T21:26:37.731448300Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-04-17T01:37:28.063082800Z" />
   </component>
 </project>

--- a/ScoutingRadar2022/app/src/main/java/org/stormroboticsnj/scoutingradar2022/homefragment/MatchRecordFragment.java
+++ b/ScoutingRadar2022/app/src/main/java/org/stormroboticsnj/scoutingradar2022/homefragment/MatchRecordFragment.java
@@ -47,23 +47,43 @@ public class MatchRecordFragment extends Fragment {
     public View onCreateView(
             LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
+
         View view = inflater.inflate(R.layout.fragment_match_record_list, container, false);
 
-        // Get the recycler view
-        RecyclerView recyclerView = view.findViewById(R.id.record_recycler);
-        // Create the adapter
-        final MatchRecordRecyclerViewAdapter adapter =
-                new MatchRecordRecyclerViewAdapter(new MatchRecordRecyclerViewAdapter.RecordDiff());
-        // Set up the recycler view with the adapter
-        Context context = view.getContext();
-        recyclerView.setLayoutManager(new LinearLayoutManager(context));
-        recyclerView.setAdapter(adapter);
+        // For the Objective Match Record
+            // Get the recycler view
+            RecyclerView recyclerView = view.findViewById(R.id.record_recycler);
+            // Create the adapter
+            final MatchRecordRecyclerViewAdapter adapter =
+                    new MatchRecordRecyclerViewAdapter(new MatchRecordRecyclerViewAdapter.RecordDiff());
+            // Set up the recycler view with the adapter
+            Context context = view.getContext();
+            recyclerView.setLayoutManager(new LinearLayoutManager(context));
+            recyclerView.setAdapter(adapter);
 
-        // Create the ViewModel
-        MatchViewModel mMatchViewModel = new ViewModelProvider(this).get(MatchViewModel.class);
+            // Create the ViewModel
+            MatchViewModel mMatchViewModel = new ViewModelProvider(this).get(MatchViewModel.class);
 
-        // Connect the viewModel and thus the database with the adapter and thus the recycler view
-        mMatchViewModel.getDataList().observe(getViewLifecycleOwner(), adapter::submitList);
+            // Connect the viewModel and thus the database with the adapter and thus the recycler view
+            mMatchViewModel.getDataList().observe(getViewLifecycleOwner(), adapter::submitList);
+
+
+        // For the Pit Match Record
+            // Get the recycler view
+            RecyclerView recyclerViewPit = view.findViewById(R.id.pit_record_recycler);
+            // Create the adapter
+            final PitRecordRecyclerViewAdapter adapterPit =
+                    new PitRecordRecyclerViewAdapter(new PitRecordRecyclerViewAdapter.RecordDiff());
+            // Set up the recycler view with the adapter
+            Context contextPit = view.getContext();
+            recyclerViewPit.setLayoutManager(new LinearLayoutManager(contextPit));
+            recyclerViewPit.setAdapter(adapterPit);
+
+            // Create the ViewModel
+            PitTeamViewModel mPitTeamViewModel = new ViewModelProvider(this).get(PitTeamViewModel.class);
+
+            // Connect the viewModel and thus the database with the adapter and thus the recycler view
+            mPitTeamViewModel.getDataList().observe(getViewLifecycleOwner(), adapterPit::submitList);
 
 
         // Setting up SpeedDialView

--- a/ScoutingRadar2022/app/src/main/java/org/stormroboticsnj/scoutingradar2022/homefragment/PitRecordRecyclerViewAdapter.java
+++ b/ScoutingRadar2022/app/src/main/java/org/stormroboticsnj/scoutingradar2022/homefragment/PitRecordRecyclerViewAdapter.java
@@ -1,0 +1,76 @@
+package org.stormroboticsnj.scoutingradar2022.homefragment;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.ListAdapter;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import org.stormroboticsnj.scoutingradar2022.R;
+import org.stormroboticsnj.scoutingradar2022.database.pit.PitScoutData;
+import org.stormroboticsnj.scoutingradar2022.databinding.FragmentMatchRecordBinding;
+
+/**
+ * {@link RecyclerView.Adapter} that can display an {@link PitScoutData}.
+ */
+public class PitRecordRecyclerViewAdapter extends ListAdapter<PitScoutData, PitRecordRecyclerViewAdapter.PitRecordViewHolder> {
+    protected PitRecordRecyclerViewAdapter(
+            @NonNull
+            DiffUtil.ItemCallback<PitScoutData> diffCallback) {
+        super(diffCallback);
+    }
+
+    @NonNull
+    @Override
+    public PitRecordViewHolder onCreateViewHolder(
+            @NonNull ViewGroup parent, int viewType) {
+        return new PitRecordViewHolder(
+                FragmentMatchRecordBinding.inflate(LayoutInflater.from(parent.getContext()), parent,
+                        false));
+    }
+
+    @Override
+    public void onBindViewHolder(
+            @NonNull PitRecordViewHolder holder, int position) {
+        holder.bind(getItem(position));
+    }
+
+
+    public static class PitRecordViewHolder extends RecyclerView.ViewHolder {
+        public final TextView mTeamNumView;
+        PitScoutData mItem;
+
+        public PitRecordViewHolder(FragmentMatchRecordBinding binding) {
+            super(binding.getRoot());
+            mTeamNumView = binding.recordTextTeamNumber;
+        }
+
+        public void bind(PitScoutData item) {
+            mItem = item;
+            mTeamNumView.setText(mTeamNumView.getContext().getResources().getString(R.string.record_text_team, item.getTeamNum()));
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return super.toString() + " '" + mTeamNumView.getText() + "'";
+        }
+    }
+
+    public static class RecordDiff extends DiffUtil.ItemCallback<PitScoutData> {
+        @Override
+        public boolean areItemsTheSame(
+                @NonNull PitScoutData oldItem, @NonNull PitScoutData newItem) {
+            return oldItem == newItem;
+        }
+
+        @Override
+        public boolean areContentsTheSame(
+                @NonNull PitScoutData oldItem, @NonNull PitScoutData newItem) {
+            return (oldItem.getTeamNum() == newItem.getTeamNum());
+        }
+    }
+}

--- a/ScoutingRadar2022/app/src/main/java/org/stormroboticsnj/scoutingradar2022/homefragment/PitTeamViewModel.java
+++ b/ScoutingRadar2022/app/src/main/java/org/stormroboticsnj/scoutingradar2022/homefragment/PitTeamViewModel.java
@@ -1,0 +1,33 @@
+package org.stormroboticsnj.scoutingradar2022.homefragment;
+
+import android.app.Application;
+
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
+
+
+import org.stormroboticsnj.scoutingradar2022.database.pit.PitRepository;
+import org.stormroboticsnj.scoutingradar2022.database.pit.PitScoutData;
+
+import java.util.List;
+
+public class PitTeamViewModel extends AndroidViewModel {
+
+    private final PitRepository mRepository;
+    private final LiveData<List<PitScoutData>> mDataList;
+
+    public PitTeamViewModel (Application app) {
+        super(app);
+        mRepository = new PitRepository(app);
+        mDataList = mRepository.getDataList();
+    }
+
+    public LiveData<List<PitScoutData>> getDataList() {
+        return mDataList;
+    }
+
+    public void insert(PitScoutData team) {
+        mRepository.insert(team);
+    }
+
+}

--- a/ScoutingRadar2022/app/src/main/res/layout/fragment_match_record_list.xml
+++ b/ScoutingRadar2022/app/src/main/res/layout/fragment_match_record_list.xml
@@ -51,16 +51,31 @@
 
     <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/record_recycler"
-            app:layout_constraintTop_toBottomOf="@id/record_text_title"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            tools:listitem="@layout/fragment_match_record"
+            android:layout_height="177dp"
+            android:layout_width="379dp"
             android:padding="16dp"
-            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/record_text_title"
+            app:layout_constraintVertical_bias="0.034"
+            tools:listitem="@layout/fragment_match_record" />
 
+    <TextView
+            android:id="@+id/pit_record_text_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|center_horizontal"
+            app:layout_constraintTop_toBottomOf="@id/record_recycler"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            android:textAlignment="center"
+            android:textAppearance="?textAppearanceOverline"
+            android:textSize="16sp"
+            android:text="@string/pit_recycler_title" />
 
     <com.leinardi.android.speeddial.SpeedDialView
             android:layout_width="wrap_content"
@@ -71,6 +86,20 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:sdMainFabClosedSrc="@drawable/ic_baseline_add_24" />
+
+    <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/pit_record_recycler"
+            android:layout_height="177dp"
+            android:layout_width="379dp"
+            android:padding="16dp"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/pit_record_text_title"
+            app:layout_constraintVertical_bias="0.018"
+            tools:listitem="@layout/fragment_match_record" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ScoutingRadar2022/app/src/main/res/values/strings.xml
+++ b/ScoutingRadar2022/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="settings">Settings</string>
 
     <string name="recycler_title">Previously Scouted Matches (Objective)</string>
+    <string name="pit_recycler_title">Previously Scouted Teams (Pit)</string>
     <string name="team_number">Team Number</string>
     <string name="match_number">Match Number</string>
     <string name="user_initial">User Initials</string>


### PR DESCRIPTION
Added pit team record recycler, it is placed below the match record recycler. Whenever a team is pit scouted, it will now appear below the objective match records.

This change is so pit scouts will have an easier time sorting through their long list of teams during competitions.